### PR TITLE
Add email contact form to about page

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -493,6 +493,75 @@ blockquote {
   margin: var(--spacing-sm);
 }
 
+/* Contact Form */
+.contact-form {
+  background-color: var(--bg-secondary);
+  padding: var(--spacing-2xl);
+  border-radius: var(--border-radius);
+  margin: var(--spacing-2xl) 0;
+  border: 1px solid var(--border-color);
+  box-shadow: var(--box-shadow);
+}
+
+.form-group {
+  margin-bottom: var(--spacing-lg);
+}
+
+.form-group label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: var(--spacing-sm);
+  color: var(--text-primary);
+}
+
+.form-group input,
+.form-group textarea {
+  width: 100%;
+  padding: var(--spacing-md);
+  border: 2px solid var(--border-color);
+  border-radius: var(--border-radius);
+  font-family: var(--font-primary);
+  font-size: 1rem;
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-group input:focus,
+.form-group textarea:focus {
+  outline: none;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+}
+
+.form-group textarea {
+  resize: vertical;
+  min-height: 120px;
+}
+
+.submit-btn {
+  background-color: var(--primary-color);
+  color: white;
+  padding: var(--spacing-md) var(--spacing-2xl);
+  border: none;
+  border-radius: var(--border-radius);
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: inline-block;
+}
+
+.submit-btn:hover {
+  background-color: var(--primary-dark);
+  transform: translateY(-2px);
+  box-shadow: var(--box-shadow-lg);
+}
+
+.submit-btn:active {
+  transform: translateY(0);
+}
+
 /* Project Details */
 .project-details {
   background-color: var(--bg-secondary);

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,4 +1,27 @@
 ---
+/**
+ * Contact Form Configuration
+ *
+ * The contact form is currently configured to use FormSubmit (https://formsubmit.co/)
+ *
+ * TO USE FORMSUBMIT (Current configuration):
+ * - The form will send to: m.kubaszek@protonmail.com
+ * - On first submission, FormSubmit will send a confirmation email
+ * - Click the link in that email to activate the form
+ * - No signup required!
+ *
+ * TO SWITCH TO FORMSPREE:
+ * 1. Sign up at https://formspree.io/
+ * 2. Create a new form and get your form endpoint
+ * 3. Replace the form action with: https://formspree.io/f/YOUR_FORM_ID
+ * 4. Remove the FormSubmit hidden inputs (_subject, _captcha, _template)
+ *
+ * TO SWITCH TO WEB3FORMS:
+ * 1. Get your access key at https://web3forms.com/
+ * 2. Replace the form action with: https://api.web3forms.com/submit
+ * 3. Add: <input type="hidden" name="access_key" value="YOUR_ACCESS_KEY">
+ * 4. Remove the FormSubmit hidden inputs
+ */
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
@@ -186,7 +209,38 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       <li>Consulting and collaboration</li>
     </ul>
 
-    <h3>Get In Touch</h3>
+    <h3>Send Me a Message</h3>
+
+    <form class="contact-form" action="https://formsubmit.co/m.kubaszek@protonmail.com" method="POST">
+      <!-- FormSubmit Configuration -->
+      <input type="hidden" name="_subject" value="New contact from mkubasz.github.io">
+      <input type="hidden" name="_captcha" value="false">
+      <input type="hidden" name="_template" value="table">
+
+      <div class="form-group">
+        <label for="name">Name *</label>
+        <input type="text" id="name" name="name" required placeholder="Your Name">
+      </div>
+
+      <div class="form-group">
+        <label for="email">Email *</label>
+        <input type="email" id="email" name="email" required placeholder="your.email@example.com">
+      </div>
+
+      <div class="form-group">
+        <label for="subject">Subject *</label>
+        <input type="text" id="subject" name="subject" required placeholder="What would you like to discuss?">
+      </div>
+
+      <div class="form-group">
+        <label for="message">Message *</label>
+        <textarea id="message" name="message" rows="6" required placeholder="Tell me about your project or question..."></textarea>
+      </div>
+
+      <button type="submit" class="submit-btn">Send Message</button>
+    </form>
+
+    <h3>Other Ways to Reach Me</h3>
 
     <p><strong>Email:</strong></p>
     <ul>


### PR DESCRIPTION
- Add contact form with name, email, subject, and message fields
- Configure form to use FormSubmit service (no signup required)
- Add comprehensive form styling matching site design
- Include configuration documentation for switching between FormSubmit, Formspree, and Web3Forms
- Form sends to m.kubaszek@protonmail.com
- Requires email confirmation on first submission to activate